### PR TITLE
fix: only attach to normal buffers

### DIFF
--- a/lua/copilot/util.lua
+++ b/lua/copilot/util.lua
@@ -107,7 +107,7 @@ function M.should_attach()
     return false, "buffer not 'buflisted'"
   end
 
-  if not vim.bo.buftype == "" then
+  if vim.bo.buftype ~= "" then
     return false, "buffer 'buftype' is " .. vim.bo.buftype
   end
 


### PR DESCRIPTION
`not vim.bo.buftype == ""` means `(not vim.bo.buftype) == ""` in Lua…