### PR TITLE
feat: trigger suggestion using the accept keymap

### DIFF
--- a/lua/copilot/suggestion.lua
+++ b/lua/copilot/suggestion.lua
@@ -446,6 +446,12 @@ end
 function mod.accept(modifier)
   local ctx = get_ctx()
 
+  -- no suggestion request yet
+  if not ctx.first then
+    schedule(ctx)
+    return
+  end
+
   local suggestion = get_current_suggestion(ctx)
   if not suggestion or vim.fn.empty(suggestion.text) == 1 then
     return


### PR DESCRIPTION
This PR adds the ability to trigger a suggestion using the accept keymap, in addition to the next/prev keymaps. It doesn't change existing behavior but improves the workflow by letting users generate and accept the first suggestion seamlessly, without needing to switch keys.